### PR TITLE
adds axios interceptor to handle req to refresh token

### DIFF
--- a/src/utilities/axiosConfig.tsx
+++ b/src/utilities/axiosConfig.tsx
@@ -5,5 +5,30 @@ const instance = axios.create({
     withCredentials: true,
 });
 
+instance.interceptors.response.use(response => {
+    return response;
+}, async error => {
+    const { config, response } = error;
+    const originalRequest = config;
+
+    if (response && response.status === 401) {
+        if (response.data && response.data.error === 'Invalid token') {
+            await axios.get('http://127.0.0.1:5000/api/user/logout');
+            window.location.href = '/';
+            return Promise.reject(error);
+        } else if (response.data && response.data.error === 'Token expired') {
+            try {
+                await axios.get('http://127.0.0.1:5000/api/user/refresh', {
+                    withCredentials: true,
+                });
+                return instance(originalRequest);
+    
+            } catch (error) {
+                console.log(error);
+            }
+        }
+    }
+});
+
 
 export default instance;


### PR DESCRIPTION
Adds Axios interceptor to integrate with the backend's refresh and access token workflow

Axios Config --> interceptor:
- if 401 token invalid, force logout
- if 401 token expired, initiate refresh and then retry the original request